### PR TITLE
feat(simulation): force output node

### DIFF
--- a/simulation/createGBM.ibf
+++ b/simulation/createGBM.ibf
@@ -76,6 +76,7 @@ function create_mcmc_graph (filename, threshold, edges, nodes)
 		}
 	}
 	
+        fprintf (filename, "\t{rank=sink;\"Vir\";}\n");
 	fprintf (filename, "}\n");
 	return 0;
 }


### PR DESCRIPTION
Force to locate the output node at the bottom of the diagram